### PR TITLE
Added support for - as a valid character in the LHS of rules

### DIFF
--- a/syntaxes/ebnf.json
+++ b/syntaxes/ebnf.json
@@ -69,7 +69,7 @@
     "syntax-rule": {
       "comment": "A <syntax rule> defines the sequences of symbols represented by a <meta identifier>",
       "name": "meta.syntax.rule.ebnf",
-      "begin": "((?:[a-zA-Z])(?:\\w*))(?:\\s)*(=)*(?:\\s)*",
+      "begin": "((?:[a-zA-Z])(?:(?:\\w|\\-)*))(?:\\s)*(=)*(?:\\s)*",
       "beginCaptures": {
         "1": {
           "name": "keyword.syntax.rule.ebnf"


### PR DESCRIPTION
Hello,
I added support for highlighting hyphen (-) separated rule names. Seems to be working.