### PR TITLE
Support markdown fenced code block injection

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     },
     "license": "MIT",
     "categories": [
-        "Languages"
+        "Programming Languages"
     ],
     "keywords": [
         "ebnf",
@@ -34,7 +34,7 @@
                 "id": "ebnf",
                 "aliases": [
                     "EBNF",
-                    "Extended Backus–Naur Form"
+                    "Extended Backus-Naur Form"
                 ],
                 "extensions": [
                     ".ebnf"
@@ -47,6 +47,16 @@
                 "language": "ebnf",
                 "scopeName": "source.ebnf",
                 "path": "syntaxes/ebnf.json"
+            },
+            {
+                "scopeName": "markdown.ebnf.codeblock",
+                "path": "./syntaxes/codeblock.json",
+                "injectTo": [
+                    "text.html.markdown"
+                ],
+                "embeddedLanguages": {
+                    "meta.embedded.block.ebnf": "ebnf"
+                }
             }
         ]
     }

--- a/syntaxes/codeblock.json
+++ b/syntaxes/codeblock.json
@@ -1,0 +1,45 @@
+{
+	"fileTypes": [],
+	"injectionSelector": "L:text.html.markdown",
+	"patterns": [
+		{
+			"include": "#ebnf-code-block"
+		}
+	],
+	"repository": {
+		"ebnf-code-block": {
+			"begin": "(^|\\G)(\\s*)(\\`{3,}|~{3,})\\s*(?i:(ebnf)(\\s+[^`~]*)?$)",
+			"name": "markup.fenced_code.block.markdown",
+			"end": "(^|\\G)(\\2|\\s{0,3})(\\3)\\s*$",
+			"beginCaptures": {
+				"3": {
+					"name": "punctuation.definition.markdown"
+				},
+				"4": {
+					"name": "fenced_code.block.language.markdown"
+				},
+				"5": {
+					"name": "fenced_code.block.language.attributes.markdown"
+				}
+			},
+			"endCaptures": {
+				"3": {
+					"name": "punctuation.definition.markdown"
+				}
+			},
+			"patterns": [
+				{
+					"begin": "(^|\\G)(\\s*)(.*)",
+					"while": "(^|\\G)(?!\\s*([`~]{3,})\\s*$)",
+					"contentName": "meta.embedded.block.ebnf",
+					"patterns": [
+						{
+							"include": "source.ebnf"
+						}
+					]
+				}
+			]
+		}
+	},
+	"scopeName": "markdown.ebnf.codeblock"
+}


### PR DESCRIPTION
I've been writing a lot of EBNF snippets in my notes for my programming languages class, which I write in Markdown. Unfortunately, this extension doesn't highlight EBNF snippets in Markdown at the moment, so they are all coloured as plain text.

So, this PR adds support for highlighting EBNF code snippets in markdown fenced code blocks. This is mostly based on the code in [this example repo](https://github.com/mjbvz/vscode-fenced-code-block-grammar-injection-example).

Also, I changed the category from "Languages" to "Programming Languages" and replaced a weird unicode symbol in the aliases section in package.json both at VSCode's recommendation.