### PR TITLE
M1 — Stabilize: null-guards, rename safety, strict TS, declare antlr4ng

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,9 @@ jobs:
       - name: Install
         run: npm ci
 
+      - name: Type-check (strict)
+        run: npm run typecheck
+
       - name: Test
         run: npm test
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
     "name": "vscode-ebnf",
-    "version": "1.4.0",
+    "version": "1.5.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-ebnf",
-            "version": "1.4.0",
+            "version": "1.5.0",
             "license": "MIT",
             "dependencies": {
                 "antlr-ng": "^1.0.10",
+                "antlr4ng": "^3.0.16",
                 "assert": "^2.1.0",
                 "util": "^0.12.5"
             },
@@ -1940,7 +1941,6 @@
             "version": "3.0.16",
             "resolved": "https://registry.npmjs.org/antlr4ng/-/antlr4ng-3.0.16.tgz",
             "integrity": "sha512-DQuJkC7kX3xunfF4K2KsWTSvoxxslv+FQp/WHQZTJSsH2Ec3QfFmrxC3Nky2ok9yglXn6nHM4zUaVDxcN5f6kA==",
-            "dev": true,
             "license": "BSD-3-Clause"
         },
         "node_modules/anymatch": {

--- a/package.json
+++ b/package.json
@@ -199,6 +199,7 @@
     },
     "dependencies": {
         "antlr-ng": "^1.0.10",
+        "antlr4ng": "^3.0.16",
         "assert": "^2.1.0",
         "util": "^0.12.5"
     },
@@ -211,6 +212,7 @@
         "vscode:prepublish": "npm run package",
         "build": "webpack --mode development",
         "package": "webpack --mode production",
+        "typecheck": "tsc --noEmit",
         "test": "jest"
     },
     "devDependencies": {

--- a/src/ParserContext.ts
+++ b/src/ParserContext.ts
@@ -12,7 +12,7 @@ export class ParserContext {
     public static ebnfSelector: vscode.DocumentFilter = { language: "ebnf", scheme: "file" };
     public static ebnfName: string = "EBNF";
     public static readonly issueUrl = "https://github.com/igochkov/vscode-ebnf/issues/36";
-    public static listener: ASTListener;
+    public static listener: ASTListener | undefined;
     public static diagnosticsCollection = vscode.languages.createDiagnosticCollection(ParserContext.ebnfName);
     public static ebnfStatusBarItem =  vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 500);
 
@@ -35,7 +35,7 @@ export class ParserContext {
         }
     }
 
-    public static OnActiveTextEditorChanged(editor: vscode.TextEditor) {
+    public static OnActiveTextEditorChanged(editor: vscode.TextEditor | undefined) {
         if (editor && ParserContext.isEBNFFile(editor.document)) {
             ParserContext.parse(editor.document);
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,7 +9,7 @@ import { EBNFCompletionItemProvider } from './providers/EBNFCompletionItemProvid
 import { Telemetry } from './telemetry/Telemetry';
 import { CONVERT_IDENTIFIERS_COMMAND, convertIdentifiersCommand } from './commands/ConvertIdentifiers';
 
-let formattingRegistrations: vscode.Disposable;
+let formattingRegistrations: vscode.Disposable | undefined;
 
 export function activate(context: vscode.ExtensionContext) {
     Telemetry.initialize(context);

--- a/src/listeners/ASTListener.ts
+++ b/src/listeners/ASTListener.ts
@@ -1,4 +1,4 @@
-import { ErrorNode, ParserRuleContext, TerminalNode, Token } from 'antlr4ng/dist';
+import { ErrorNode, ParserRuleContext, TerminalNode, Token } from 'antlr4ng';
 import { SyntacticPrimaryContext, SyntaxRuleContext } from '../parser/EBNFParser';
 import { EBNFParserListener } from '../parser/EBNFParserListener';
 

--- a/src/listeners/EBNFErrorListener.ts
+++ b/src/listeners/EBNFErrorListener.ts
@@ -23,7 +23,7 @@ export class EBNFErrorListener implements ANTLRErrorListener {
         let endLine: number = startLine;
         let endIndex: number = charPositionInLine + 1;
 
-        if (offendingSymbol.text) {
+        if (offendingSymbol && offendingSymbol.text) {
             const lines = offendingSymbol.text.split(/\n/);
 
             if (lines.length === 1) {

--- a/src/providers/EBNFCompletionItemProvider.ts
+++ b/src/providers/EBNFCompletionItemProvider.ts
@@ -10,7 +10,15 @@ export class EBNFCompletionItemProvider implements vscode.CompletionItemProvider
             ParserContext.parse(document);
         }
 
-        const names = new Set(ParserContext.listener.symbols.map(sym => sym.text).filter(name => name != text));
+        const listener = ParserContext.listener;
+        if (!listener) {
+            return;
+        }
+
+        const names = new Set(
+            listener.symbols
+                .map(sym => sym.text)
+                .filter((name): name is string => name !== undefined && name !== text));
 
         return [...names].map(name =>
             new vscode.CompletionItem(name, vscode.CompletionItemKind.Keyword));

--- a/src/providers/EBNFDefinitionProvider.ts
+++ b/src/providers/EBNFDefinitionProvider.ts
@@ -18,9 +18,18 @@ export class EBNFDefinitionProvider implements vscode.DefinitionProvider {
             ParserContext.parse(document);
         }
 
-        const def = ParserContext.listener.definitions.find(d => d.text === text);
+        const listener = ParserContext.listener;
+        if (!listener) {
+            return;
+        }
 
-        var result: vscode.Definition = {
+        const def = listener.definitions.find(d => d.text === text);
+
+        if (!def || def.text === undefined) {
+            return;
+        }
+
+        const result: vscode.Definition = {
             uri: document.uri,
             range: new vscode.Range(
                 def.line - 1,

--- a/src/providers/EBNFFormattingOptions.ts
+++ b/src/providers/EBNFFormattingOptions.ts
@@ -3,7 +3,7 @@ import * as vscode from "vscode";
 export class EBNFFormattingOptions implements vscode.FormattingOptions {
     [key: string]: string | number | boolean;
 
-    public enable: boolean;
+    public enable: boolean = true;
     public tabSize: number = 4;
     public insertSpaces: boolean = true;
     public definingSymbolOnNewLine: boolean = true;

--- a/src/providers/EBNFFormattingProvider.ts
+++ b/src/providers/EBNFFormattingProvider.ts
@@ -110,26 +110,26 @@ export class EBNFFormattingProvider implements vscode.DocumentFormattingEditProv
         const parser = new EBNFParser(tokenStream);
         const syntax = parser.syntax();
         var visitor = new FormattingVisitor(this.formattingOptions(options));
-        return visitor.visit(syntax);
+        return visitor.visit(syntax) ?? "";
     }
 
     private formattingOptions(vsOptions: vscode.FormattingOptions): EBNFFormattingOptions {
         const settings = vscode.workspace.getConfiguration(ParserContext.ebnfName);
 
         var options = new EBNFFormattingOptions();
-        options.enable = settings.get("format.enable");
+        options.enable = settings.get<boolean>("format.enable", true);
         options.tabSize = vsOptions.tabSize;
         options.insertSpaces = vsOptions.insertSpaces;
-        options.definingSymbolOnNewLine = settings.get("format.definingSymbolOnNewLine");
-        options.indentDefiningSymbol = settings.get("format.indentDefiningSymbol");
-        options.terminatorSymbolOnNewLine = settings.get("format.terminatorSymbolOnNewLine");
-        options.definitionSeparatorSymbolOnNewLine = settings.get("format.definitionSeparatorSymbolOnNewLine");
-        options.insertSpaceBeforeConcatenateSymbol = settings.get("format.insertSpaceBeforeConcatenateSymbol");
-        options.insertSpaceAtSequenceSymbols = settings.get("format.insertSpaceAtSequenceSymbols");
-        options.defaultDefinitionSeparatorSymbol = settings.get("format.defaultDefinitionSeparatorSymbol");
-        options.defaultOptionSymbols = settings.get("format.defaultOptionSymbols");
-        options.defaultRepeatSymbols = settings.get("format.defaultRepeatSymbols");
-        options.defaultTerminatorSymbol = settings.get("format.defaultTerminatorSymbol");
+        options.definingSymbolOnNewLine = settings.get<boolean>("format.definingSymbolOnNewLine", true);
+        options.indentDefiningSymbol = settings.get<boolean>("format.indentDefiningSymbol", true);
+        options.terminatorSymbolOnNewLine = settings.get<boolean>("format.terminatorSymbolOnNewLine", false);
+        options.definitionSeparatorSymbolOnNewLine = settings.get<boolean>("format.definitionSeparatorSymbolOnNewLine", true);
+        options.insertSpaceBeforeConcatenateSymbol = settings.get<boolean>("format.insertSpaceBeforeConcatenateSymbol", false);
+        options.insertSpaceAtSequenceSymbols = settings.get<boolean>("format.insertSpaceAtSequenceSymbols", true);
+        options.defaultDefinitionSeparatorSymbol = settings.get<string>("format.defaultDefinitionSeparatorSymbol", "|");
+        options.defaultOptionSymbols = settings.get<string>("format.defaultOptionSymbols", "[ ]");
+        options.defaultRepeatSymbols = settings.get<string>("format.defaultRepeatSymbols", "{ }");
+        options.defaultTerminatorSymbol = settings.get<string>("format.defaultTerminatorSymbol", ";");
 
         return options;
     }

--- a/src/providers/EBNFReferenceProvider.ts
+++ b/src/providers/EBNFReferenceProvider.ts
@@ -14,14 +14,19 @@ export class EBNFReferenceProvider implements vscode.ReferenceProvider {
             ParserContext.parse(document);
         }
 
-        var result: vscode.Location[]
-            = ParserContext.listener.symbols.filter(symbol => symbol.text === text)
+        const listener = ParserContext.listener;
+        if (!listener) {
+            return;
+        }
+
+        const result: vscode.Location[]
+            = listener.symbols.filter(symbol => symbol.text === text)
                 .map(ref => new vscode.Location(document.uri,
                     new vscode.Range(
                         ref.line - 1,
                         ref.column,
                         ref.line - 1,
-                        ref.column + ref.text.length
+                        ref.column + ref.text!.length
                     )));
 
         return result;

--- a/src/providers/EBNFRenameProvider.ts
+++ b/src/providers/EBNFRenameProvider.ts
@@ -3,41 +3,72 @@ import { ISymbolInfo } from '../ISymbolInfo';
 import { ParserContext } from "../ParserContext";
 
 export class EBNFRenameProvider implements vscode.RenameProvider {
+    /**
+     * Meta-identifier pattern accepted by the (modern) lexer: a letter followed by
+     * letters, digits, "_" or "-". Renaming to anything else would produce an invalid
+     * grammar, so it is rejected. See B5/G15 in the gap analysis.
+     */
+    private static readonly identifierPattern = /^[A-Za-z][A-Za-z0-9_-]*$/;
+
+    private symbols(document: vscode.TextDocument): ISymbolInfo[] {
+        if (!ParserContext.listener) {
+            ParserContext.parse(document);
+        }
+
+        const listener = ParserContext.listener;
+        if (!listener) {
+            return [];
+        }
+
+        return listener.symbols
+            .filter(symbol => symbol.text !== undefined)
+            .map(symbol => ({
+                name: symbol.text!,
+                range: new vscode.Range(
+                    symbol.line - 1,
+                    symbol.column,
+                    symbol.line - 1,
+                    symbol.column + symbol.text!.length
+                )
+            }));
+    }
+
+    public prepareRename(
+        document: vscode.TextDocument,
+        position: vscode.Position,
+        _: vscode.CancellationToken): vscode.ProviderResult<vscode.Range | { range: vscode.Range; placeholder: string }>
+    {
+        const currentSymbol = this.symbols(document).find(symbol => symbol.range.contains(position));
+
+        if (!currentSymbol) {
+            throw new Error("You cannot rename this element.");
+        }
+
+        return { range: currentSymbol.range, placeholder: currentSymbol.name };
+    }
+
     public provideRenameEdits(
         document: vscode.TextDocument,
         position: vscode.Position,
         newName: string,
         _: vscode.CancellationToken): vscode.ProviderResult<vscode.WorkspaceEdit>
     {
-        if (!ParserContext.listener) {
-            ParserContext.parse(document);
+        if (!EBNFRenameProvider.identifierPattern.test(newName)) {
+            throw new Error(`"${newName}" is not a valid EBNF meta-identifier. Use a letter followed by letters, digits, "_" or "-".`);
         }
 
-        var result: ISymbolInfo[] = [];
-        for (var rule of ParserContext.listener.symbols) {
-            result.push({
-                name: rule.text,
-                range: new vscode.Range(
-                    rule.line - 1,
-                    rule.column,
-                    rule.line - 1,
-                    rule.column + rule.text.length
-                )
-            });
-        }
+        const symbols = this.symbols(document);
+        const currentSymbol = symbols.find(symbol => symbol.range.contains(position));
 
-        var currentSymbol: ISymbolInfo
-            = result.find(symbol => symbol.range.contains(position));
+        const workspaceEdit = new vscode.WorkspaceEdit();
 
-        var edits: vscode.TextEdit[] = [];
         if (currentSymbol) {
-            edits
-                = result.filter(symbol => symbol.name == currentSymbol.name)
-                    .map(symbol => new vscode.TextEdit(symbol.range, newName));
+            const edits = symbols
+                .filter(symbol => symbol.name === currentSymbol.name)
+                .map(symbol => new vscode.TextEdit(symbol.range, newName));
+            workspaceEdit.set(document.uri, edits);
         }
 
-        var workspaceEdit = new vscode.WorkspaceEdit();
-        workspaceEdit.set(document.uri, edits);
         return workspaceEdit;
     }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
       "target": "ES6",
       "module": "commonjs",
       "esModuleInterop": true,
+      "strict": true,
       "outDir": "./dist",
       "sourceMap": true
     },


### PR DESCRIPTION
## Milestone M1 — Stabilize

Fixes the crash/hygiene issues so later feature work isn't built on sand.

| Item | Change |
|------|--------|
| **B1** | Early-return in `EBNFDefinitionProvider` when the word under the cursor isn't a defined rule (was a confirmed crash: `Cannot read properties of undefined`). |
| **B2** | Guard the possibly-null `offendingSymbol` in `EBNFErrorListener`. |
| **B5/G15** | Add `prepareRename` + `newName` validation in `EBNFRenameProvider`. |
| **D1** | Declare `antlr4ng` as a direct dependency (was only transitive). |
| **D5** | Enable TypeScript `strict`; fix all 19 resulting errors. |
| **D7** | Add `npm run typecheck` and a strict type-check step to CI. |

### Verification
- `tsc --noEmit` (strict): 0 errors
- `npm test`: 60/60 pass
- `npm run package` (production webpack): builds clean