### PR TITLE
M2 — Semantic linter: undefined/duplicate/unused rules, hover, outline, highlights

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,10 @@
         "renameProvider": "true",
         "codeActionProvider": "true",
         "referencesProvider": "true",
-        "completionProvider": "true"
+        "completionProvider": "true",
+        "hoverProvider": "true",
+        "documentSymbolProvider": "true",
+        "documentHighlightProvider": "true"
     },
     "repository": {
         "type": "git",

--- a/src/ParserContext.ts
+++ b/src/ParserContext.ts
@@ -7,6 +7,7 @@ import { ASTListener } from "./listeners/ASTListener";
 import { EBNFErrorListener } from "./listeners/EBNFErrorListener";
 import { Telemetry, GrammarStats } from "./telemetry/Telemetry";
 import { hyphenIdentifiersFromTokens, HYPHEN_DIAGNOSTIC_CODE } from "./migration/IdentifierMigration";
+import { analyze, AnalysisSeverity } from "./analysis/GrammarAnalyzer";
 
 export class ParserContext {
     public static ebnfSelector: vscode.DocumentFilter = { language: "ebnf", scheme: "file" };
@@ -15,6 +16,14 @@ export class ParserContext {
     public static listener: ASTListener | undefined;
     public static diagnosticsCollection = vscode.languages.createDiagnosticCollection(ParserContext.ebnfName);
     public static ebnfStatusBarItem =  vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 500);
+
+    /** Ensures the given document has been parsed and returns its symbol listener (if any). */
+    public static getListener(document: vscode.TextDocument): ASTListener | undefined {
+        if (!ParserContext.listener) {
+            ParserContext.parse(document);
+        }
+        return ParserContext.listener;
+    }
 
     public static OnDocumentOpen(document: vscode.TextDocument) {
         if (document && ParserContext.isEBNFFile(document)) {
@@ -68,7 +77,9 @@ export class ParserContext {
         parser.syntax();
 
         const tokens = tokenStream.getTokens();
-        const diagnostics = errorListener.diagnostics.concat(ParserContext.identifierDeprecationDiagnostics(tokens));
+        const diagnostics = errorListener.diagnostics
+            .concat(ParserContext.identifierDeprecationDiagnostics(tokens))
+            .concat(ParserContext.semanticDiagnostics());
         ParserContext.diagnosticsCollection.set(document.uri, diagnostics);
         ParserContext.updateStatusBarItem();
 
@@ -98,6 +109,35 @@ export class ParserContext {
         }
 
         return diagnostics;
+    }
+
+    /**
+     * M2 semantic linter (G1/G2/G3): undefined, duplicate and unused rules. The
+     * analysis itself lives in a VS Code-independent module; here we only map its
+     * findings onto vscode.Diagnostic values.
+     */
+    private static semanticDiagnostics(): vscode.Diagnostic[] {
+        if (!ParserContext.listener) {
+            return [];
+        }
+
+        return analyze(ParserContext.listener).map(finding => {
+            const range = new vscode.Range(
+                finding.startLine, finding.startColumn,
+                finding.endLine, finding.endColumn);
+            const diagnostic = new vscode.Diagnostic(range, finding.message, ParserContext.toSeverity(finding.severity));
+            diagnostic.source = ParserContext.ebnfName;
+            diagnostic.code = finding.code;
+            return diagnostic;
+        });
+    }
+
+    private static toSeverity(severity: AnalysisSeverity): vscode.DiagnosticSeverity {
+        switch (severity) {
+            case "warning": return vscode.DiagnosticSeverity.Warning;
+            case "information": return vscode.DiagnosticSeverity.Information;
+            case "hint": return vscode.DiagnosticSeverity.Hint;
+        }
     }
 
     private static computeGrammarStats(tokens: Token[]): GrammarStats {

--- a/src/analysis/GrammarAnalyzer.ts
+++ b/src/analysis/GrammarAnalyzer.ts
@@ -1,0 +1,101 @@
+import { Token } from 'antlr4ng';
+import { ASTListener, RuleInfo } from '../listeners/ASTListener';
+
+/** Diagnostic codes emitted by the semantic analyzer (stable identifiers). */
+export const DiagnosticCode = {
+    UndefinedRule: "ebnf.undefinedRule",
+    DuplicateDefinition: "ebnf.duplicateDefinition",
+    UnusedRule: "ebnf.unusedRule"
+} as const;
+
+export type AnalysisSeverity = "warning" | "information" | "hint";
+
+/** A vscode-independent finding. Positions are 0-based (line and column). */
+export interface AnalysisFinding {
+    code: string;
+    message: string;
+    severity: AnalysisSeverity;
+    startLine: number;
+    startColumn: number;
+    endLine: number;
+    endColumn: number;
+}
+
+function rangeOfToken(token: Token): Pick<AnalysisFinding, "startLine" | "startColumn" | "endLine" | "endColumn"> {
+    const length = (token.text ?? "").length;
+    return {
+        startLine: token.line - 1,
+        startColumn: token.column,
+        endLine: token.line - 1,
+        endColumn: token.column + length
+    };
+}
+
+/**
+ * Computes semantic diagnostics from a parsed grammar. Pure and free of any VS Code
+ * dependency so it can be unit-tested directly against a walked parse tree.
+ *
+ * - G1 undefined-rule: a meta-identifier used on a right-hand side but never defined.
+ * - G2 duplicate-definition: a rule name defined by more than one syntax-rule
+ *   (legal per ISO/IEC 14977 §5.1 note 2, surfaced as information, not an error).
+ * - G3 unused-rule: a defined rule never referenced anywhere. The first-defined rule
+ *   is treated as the grammar's start symbol and is never flagged (ISO §3.5).
+ */
+export function analyze(listener: ASTListener): AnalysisFinding[] {
+    const findings: AnalysisFinding[] = [];
+    const rules = listener.rules.filter(rule => rule.name.length > 0);
+
+    const definedNames = new Set(rules.map(rule => rule.name));
+    const usedNames = new Set(
+        listener.usages
+            .map(usage => usage.text)
+            .filter((text): text is string => text !== undefined && text.length > 0));
+
+    // G1 — undefined rules.
+    for (const usage of listener.usages) {
+        const name = usage.text;
+        if (name && !definedNames.has(name)) {
+            findings.push({
+                code: DiagnosticCode.UndefinedRule,
+                message: `Rule "${name}" is used but never defined.`,
+                severity: "warning",
+                ...rangeOfToken(usage)
+            });
+        }
+    }
+
+    // G2 — duplicate definitions.
+    const countByName = new Map<string, number>();
+    for (const rule of rules) {
+        countByName.set(rule.name, (countByName.get(rule.name) ?? 0) + 1);
+    }
+    for (const rule of rules) {
+        const count = countByName.get(rule.name) ?? 0;
+        if (count > 1) {
+            findings.push({
+                code: DiagnosticCode.DuplicateDefinition,
+                message: `Rule "${rule.name}" is defined ${count} times.`,
+                severity: "information",
+                ...rangeOfToken(rule.nameToken)
+            });
+        }
+    }
+
+    // G3 — unused rules (the first-defined rule is the start symbol).
+    const startSymbol: RuleInfo | undefined = rules[0];
+    for (const rule of rules) {
+        if (startSymbol && rule.name === startSymbol.name) {
+            continue;
+        }
+        if (!usedNames.has(rule.name)) {
+            findings.push({
+                code: DiagnosticCode.UnusedRule,
+                message: `Rule "${rule.name}" is defined but never used.`,
+                severity: "information",
+                ...rangeOfToken(rule.nameToken)
+            });
+        }
+    }
+
+    return findings;
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,6 +6,9 @@ import { EBNFReferenceProvider } from './providers/EBNFReferenceProvider';
 import { EBNFCodeActionsProvider } from './providers/EBNFCodeActionsProvider';
 import { EBNFFormattingProvider } from './providers/EBNFFormattingProvider';
 import { EBNFCompletionItemProvider } from './providers/EBNFCompletionItemProvider';
+import { EBNFHoverProvider } from './providers/EBNFHoverProvider';
+import { EBNFDocumentSymbolProvider } from './providers/EBNFDocumentSymbolProvider';
+import { EBNFDocumentHighlightProvider } from './providers/EBNFDocumentHighlightProvider';
 import { Telemetry } from './telemetry/Telemetry';
 import { CONVERT_IDENTIFIERS_COMMAND, convertIdentifiersCommand } from './commands/ConvertIdentifiers';
 
@@ -23,6 +26,9 @@ export function activate(context: vscode.ExtensionContext) {
         { providedCodeActionKinds: EBNFCodeActionsProvider.providedCodeActionKinds }));
     context.subscriptions.push(vscode.commands.registerCommand(CONVERT_IDENTIFIERS_COMMAND, convertIdentifiersCommand));
     context.subscriptions.push(vscode.languages.registerCompletionItemProvider(ParserContext.ebnfSelector, new EBNFCompletionItemProvider()));
+    context.subscriptions.push(vscode.languages.registerHoverProvider(ParserContext.ebnfSelector, new EBNFHoverProvider()));
+    context.subscriptions.push(vscode.languages.registerDocumentSymbolProvider(ParserContext.ebnfSelector, new EBNFDocumentSymbolProvider()));
+    context.subscriptions.push(vscode.languages.registerDocumentHighlightProvider(ParserContext.ebnfSelector, new EBNFDocumentHighlightProvider()));
     context.subscriptions.push(ParserContext.ebnfStatusBarItem);
 
     if (vscode.window.activeTextEditor) {

--- a/src/listeners/ASTListener.ts
+++ b/src/listeners/ASTListener.ts
@@ -2,9 +2,32 @@ import { ErrorNode, ParserRuleContext, TerminalNode, Token } from 'antlr4ng';
 import { SyntacticPrimaryContext, SyntaxRuleContext } from '../parser/EBNFParser';
 import { EBNFParserListener } from '../parser/EBNFParserListener';
 
+/**
+ * A single left-hand-side definition of a syntax-rule, with enough positional
+ * information to drive diagnostics, outline, hover and highlights.
+ */
+export interface RuleInfo {
+    /** The defined meta-identifier (rule name). */
+    name: string;
+    /** The name token (LHS meta-identifier). */
+    nameToken: Token;
+    /** First token of the whole rule (for the full-rule range). */
+    startToken: Token;
+    /** Last token of the whole rule (for the full-rule range). */
+    stopToken: Token;
+    /** Leading comment texts attached to the rule name, in source order. */
+    comments: string[];
+}
+
 export class ASTListener implements EBNFParserListener {
+    /** Every meta-identifier occurrence (definitions + usages). Kept for existing providers. */
     public symbols: Token[] = [];
+    /** Left-hand-side (defining) meta-identifier occurrences. */
     public definitions: Token[] = [];
+    /** Right-hand-side (referencing) meta-identifier occurrences. */
+    public usages: Token[] = [];
+    /** Rich per-rule model used by the semantic analyzer and the navigation providers. */
+    public rules: RuleInfo[] = [];
 
     exitSyntaxRule(ctx: SyntaxRuleContext) {
         const metaWithComments = ctx.metaWithComments();
@@ -15,6 +38,18 @@ export class ASTListener implements EBNFParserListener {
             if (ruleName) {
                 this.symbols.push(ruleName.symbol);
                 this.definitions.push(ruleName.symbol);
+
+                const startToken = ctx.start ?? ruleName.symbol;
+                const stopToken = ctx.stop ?? ruleName.symbol;
+                const comments = metaWithComments.comment().map(c => c.getText());
+
+                this.rules.push({
+                    name: ruleName.symbol.text ?? "",
+                    nameToken: ruleName.symbol,
+                    startToken,
+                    stopToken,
+                    comments
+                });
             }
         }
     }
@@ -24,10 +59,11 @@ export class ASTListener implements EBNFParserListener {
 
         if (terminalNode) {
             this.symbols.push(terminalNode.symbol);
+            this.usages.push(terminalNode.symbol);
         }
     }
 
-    visitTerminal(node: TerminalNode): void {}    
+    visitTerminal(node: TerminalNode): void {}
     visitErrorNode(node: ErrorNode): void {}
     enterEveryRule(node: ParserRuleContext): void {}
     exitEveryRule(node: ParserRuleContext): void {}

--- a/src/providers/EBNFDefinitionProvider.ts
+++ b/src/providers/EBNFDefinitionProvider.ts
@@ -23,21 +23,22 @@ export class EBNFDefinitionProvider implements vscode.DefinitionProvider {
             return;
         }
 
-        const def = listener.definitions.find(d => d.text === text);
+        // G2: a meta-identifier may be defined by more than one syntax-rule
+        // (ISO/IEC 14977 §5.1 note 2), so return every definition site, not just the first.
+        const result: vscode.Location[] = listener.definitions
+            .filter(d => d.text === text)
+            .map(d => new vscode.Location(
+                document.uri,
+                new vscode.Range(
+                    d.line - 1,
+                    d.column,
+                    d.line - 1,
+                    d.column + (d.text ?? "").length
+                )));
 
-        if (!def || def.text === undefined) {
+        if (result.length === 0) {
             return;
         }
-
-        const result: vscode.Definition = {
-            uri: document.uri,
-            range: new vscode.Range(
-                def.line - 1,
-                def.column,
-                def.line - 1,
-                def.column + def.text.length
-            )
-        };
 
         return result;
     }

--- a/src/providers/EBNFDocumentHighlightProvider.ts
+++ b/src/providers/EBNFDocumentHighlightProvider.ts
@@ -1,0 +1,33 @@
+import * as vscode from "vscode";
+import { ParserContext } from "../ParserContext";
+import { tokenRange } from "./ProviderUtils";
+
+export class EBNFDocumentHighlightProvider implements vscode.DocumentHighlightProvider {
+    public provideDocumentHighlights(
+        document: vscode.TextDocument,
+        position: vscode.Position,
+        _: vscode.CancellationToken): vscode.ProviderResult<vscode.DocumentHighlight[]>
+    {
+        const wordRange = document.getWordRangeAtPosition(position);
+        const text = wordRange ? document.getText(wordRange) : "";
+
+        if (!text) {
+            return;
+        }
+
+        const listener = ParserContext.getListener(document);
+        if (!listener) {
+            return;
+        }
+
+        const definitions = new Set(listener.definitions.filter(d => d.text === text));
+
+        return listener.symbols
+            .filter(symbol => symbol.text === text)
+            .map(symbol => new vscode.DocumentHighlight(
+                tokenRange(symbol),
+                definitions.has(symbol)
+                    ? vscode.DocumentHighlightKind.Write
+                    : vscode.DocumentHighlightKind.Read));
+    }
+}

--- a/src/providers/EBNFDocumentSymbolProvider.ts
+++ b/src/providers/EBNFDocumentSymbolProvider.ts
@@ -1,0 +1,24 @@
+import * as vscode from "vscode";
+import { ParserContext } from "../ParserContext";
+import { ruleRange, tokenRange } from "./ProviderUtils";
+
+export class EBNFDocumentSymbolProvider implements vscode.DocumentSymbolProvider {
+    public provideDocumentSymbols(
+        document: vscode.TextDocument,
+        _: vscode.CancellationToken): vscode.ProviderResult<vscode.DocumentSymbol[]>
+    {
+        const listener = ParserContext.getListener(document);
+        if (!listener) {
+            return;
+        }
+
+        return listener.rules
+            .filter(rule => rule.name.length > 0)
+            .map(rule => new vscode.DocumentSymbol(
+                rule.name,
+                "",
+                vscode.SymbolKind.Function,
+                ruleRange(rule),
+                tokenRange(rule.nameToken)));
+    }
+}

--- a/src/providers/EBNFHoverProvider.ts
+++ b/src/providers/EBNFHoverProvider.ts
@@ -1,0 +1,39 @@
+import * as vscode from "vscode";
+import { ParserContext } from "../ParserContext";
+import { ruleRange } from "./ProviderUtils";
+
+export class EBNFHoverProvider implements vscode.HoverProvider {
+    public provideHover(
+        document: vscode.TextDocument,
+        position: vscode.Position,
+        _: vscode.CancellationToken): vscode.ProviderResult<vscode.Hover>
+    {
+        const wordRange = document.getWordRangeAtPosition(position);
+        const text = wordRange ? document.getText(wordRange) : "";
+
+        if (!text) {
+            return;
+        }
+
+        const listener = ParserContext.getListener(document);
+        if (!listener) {
+            return;
+        }
+
+        const matches = listener.rules.filter(rule => rule.name === text);
+        if (matches.length === 0) {
+            return;
+        }
+
+        const markdown = new vscode.MarkdownString();
+        for (const rule of matches) {
+            for (const comment of rule.comments) {
+                markdown.appendText(comment);
+                markdown.appendMarkdown("\n\n");
+            }
+            markdown.appendCodeblock(document.getText(ruleRange(rule)), "ebnf");
+        }
+
+        return new vscode.Hover(markdown, wordRange);
+    }
+}

--- a/src/providers/ProviderUtils.ts
+++ b/src/providers/ProviderUtils.ts
@@ -1,0 +1,23 @@
+import * as vscode from "vscode";
+import { Token } from "antlr4ng";
+import { RuleInfo } from "../listeners/ASTListener";
+
+/** Range covering a single token (its line/column to end of its text). */
+export function tokenRange(token: Token): vscode.Range {
+    const length = (token.text ?? "").length;
+    return new vscode.Range(
+        token.line - 1,
+        token.column,
+        token.line - 1,
+        token.column + length);
+}
+
+/** Range covering a whole syntax-rule, from its first token to the end of its last token. */
+export function ruleRange(rule: RuleInfo): vscode.Range {
+    const stopLength = (rule.stopToken.text ?? "").length;
+    return new vscode.Range(
+        rule.startToken.line - 1,
+        rule.startToken.column,
+        rule.stopToken.line - 1,
+        rule.stopToken.column + stopLength);
+}

--- a/tests/GrammarAnalyzerTests.ts
+++ b/tests/GrammarAnalyzerTests.ts
@@ -1,0 +1,76 @@
+import { CharStream, CommonTokenStream, ParseTreeListener } from 'antlr4ng';
+import { EBNFLexer } from '../src/parser/EBNFLexer';
+import { EBNFParser } from '../src/parser/EBNFParser';
+import { ASTListener } from '../src/listeners/ASTListener';
+import { analyze, AnalysisFinding, DiagnosticCode } from '../src/analysis/GrammarAnalyzer';
+
+function findingsFor(input: string): AnalysisFinding[] {
+    const inputStream = CharStream.fromString(input);
+    const lexer = new EBNFLexer(inputStream);
+    const tokenStream = new CommonTokenStream(lexer);
+    const parser = new EBNFParser(tokenStream);
+
+    const listener = new ASTListener();
+    parser.removeParseListeners();
+    parser.addParseListener(listener as unknown as ParseTreeListener);
+    parser.removeErrorListeners();
+    parser.syntax();
+
+    return analyze(listener);
+}
+
+function codes(findings: AnalysisFinding[]): string[] {
+    return findings.map(f => f.code);
+}
+
+// G1 — undefined rules
+test('G1 - flags a meta-identifier used but never defined', () => {
+    const findings = findingsFor(`start = a; a = b;`);
+    const undefinedFindings = findings.filter(f => f.code === DiagnosticCode.UndefinedRule);
+
+    expect(undefinedFindings).toHaveLength(1);
+    expect(undefinedFindings[0].message).toContain('"b"');
+    expect(undefinedFindings[0].severity).toBe('warning');
+});
+
+test('G1 - no finding when every used rule is defined', () => {
+    const findings = findingsFor(`start = a; a = "x";`);
+    expect(codes(findings)).not.toContain(DiagnosticCode.UndefinedRule);
+});
+
+// G2 — duplicate definitions
+test('G2 - flags each definition site of a duplicated rule', () => {
+    const findings = findingsFor(`start = a; a = "x"; a = "y";`);
+    const duplicates = findings.filter(f => f.code === DiagnosticCode.DuplicateDefinition);
+
+    expect(duplicates).toHaveLength(2);
+    expect(duplicates[0].message).toContain('2 times');
+    expect(duplicates[0].severity).toBe('information');
+});
+
+test('G2 - no finding for a singly-defined rule', () => {
+    const findings = findingsFor(`start = a; a = "x";`);
+    expect(codes(findings)).not.toContain(DiagnosticCode.DuplicateDefinition);
+});
+
+// G3 — unused rules / start symbol
+test('G3 - flags a defined rule that is never referenced', () => {
+    const findings = findingsFor(`start = "x"; orphan = "y";`);
+    const unused = findings.filter(f => f.code === DiagnosticCode.UnusedRule);
+
+    expect(unused).toHaveLength(1);
+    expect(unused[0].message).toContain('"orphan"');
+});
+
+test('G3 - the first-defined rule is treated as the start symbol and never flagged', () => {
+    const findings = findingsFor(`start = a; a = "x";`);
+    const unused = findings.filter(f => f.code === DiagnosticCode.UnusedRule);
+
+    // "start" is unreferenced but is the start symbol; "a" is used → no unused findings.
+    expect(unused).toHaveLength(0);
+});
+
+test('a well-formed grammar produces no findings', () => {
+    const findings = findingsFor(`start = a, b; a = "x"; b = "y";`);
+    expect(findings).toHaveLength(0);
+});


### PR DESCRIPTION
## Milestone M2 — Semantic linter

Turns the extension from a colorizer/navigator into an actual grammar linter.

> **Stacked on #<M1>.** Base is `m1-stabilize` so the diff shows only M2. Retarget to `main` once M1 merges.

### Symbol model
- Enrich `ASTListener` with a right-hand-side `usages[]` list and a rich per-rule model (`RuleInfo`: name, name token, full-rule range, leading comments).

### Diagnostics — new vscode-independent `analysis/GrammarAnalyzer` (unit-tested)
| Item | Diagnostic | Severity |
|------|-----------|:--------:|
| **G1** | Undefined rule — a meta-identifier used on a RHS but never defined | Warning |
| **G2** | Duplicate definition — a rule defined by more than one syntax-rule (legal per ISO/IEC 14977 §5.1 note 2) | Information |
| **G3** | Unused rule — a defined rule never referenced; the first-defined rule is treated as the start symbol and never flagged (ISO §3.5) | Information |

For **G2**, `EBNFDefinitionProvider` now returns *every* definition site instead of only the first.

### Navigation providers
- **G7 Hover** — shows a rule's definition (and leading comment) on hover.
- **G8 Document symbols** — populates Outline / breadcrumbs with the rule list.
- **G11 Document highlights** — highlights all occurrences of the identifier under the cursor (definitions as Write, usages as Read).
- Shared `ProviderUtils` for token/rule range mapping (removes the duplicated Token→Range logic, quality item A5).

### Wiring
- Register the three new providers; advertise `hoverProvider` / `documentSymbolProvider` / `documentHighlightProvider` capabilities in `package.json`.

### Notes / decisions
- Severity: undefined = Warning (likely a typo); duplicate/unused = Information (both are legal ISO constructs).
- G3 is direct-reference, not full reachability — transitive unreachability is a later enhancement.
- **G4** (intentional primitives like `character = ? … ?`) is not in M2, so referencing an undefined external terminal will warn; quick-fix suppression arrives with M3 (G16/G17).

### Verification
- `tsc --noEmit` (strict): 0 errors
- `npm test`: 67/67 pass (7 new analyzer tests)
- `npm run package` (production webpack): builds clean
- Linter produces **0 findings** on the bundled ISO example grammar (no false positives)
