### PR TITLE
M3 — Editor polish: folding, semantic tokens, CodeLens, quick fixes, range/on-type formatting, B3

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     ],
     "capabilities": {
         "documentFormattingProvider": "true",
-        "documentRangeFormattingProvider": "false",
+        "documentRangeFormattingProvider": "true",
+        "documentOnTypeFormattingProvider": "true",
         "definitionProvider": "true",
         "renameProvider": "true",
         "codeActionProvider": "true",
@@ -32,7 +33,10 @@
         "completionProvider": "true",
         "hoverProvider": "true",
         "documentSymbolProvider": "true",
-        "documentHighlightProvider": "true"
+        "documentHighlightProvider": "true",
+        "foldingRangeProvider": "true",
+        "codeLensProvider": "true",
+        "documentSemanticTokensProvider": "true"
     },
     "repository": {
         "type": "git",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,6 +9,9 @@ import { EBNFCompletionItemProvider } from './providers/EBNFCompletionItemProvid
 import { EBNFHoverProvider } from './providers/EBNFHoverProvider';
 import { EBNFDocumentSymbolProvider } from './providers/EBNFDocumentSymbolProvider';
 import { EBNFDocumentHighlightProvider } from './providers/EBNFDocumentHighlightProvider';
+import { EBNFFoldingRangeProvider } from './providers/EBNFFoldingRangeProvider';
+import { EBNFCodeLensProvider } from './providers/EBNFCodeLensProvider';
+import { EBNFSemanticTokensProvider, EBNF_SEMANTIC_TOKENS_LEGEND } from './providers/EBNFSemanticTokensProvider';
 import { Telemetry } from './telemetry/Telemetry';
 import { CONVERT_IDENTIFIERS_COMMAND, convertIdentifiersCommand } from './commands/ConvertIdentifiers';
 
@@ -29,6 +32,9 @@ export function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(vscode.languages.registerHoverProvider(ParserContext.ebnfSelector, new EBNFHoverProvider()));
     context.subscriptions.push(vscode.languages.registerDocumentSymbolProvider(ParserContext.ebnfSelector, new EBNFDocumentSymbolProvider()));
     context.subscriptions.push(vscode.languages.registerDocumentHighlightProvider(ParserContext.ebnfSelector, new EBNFDocumentHighlightProvider()));
+    context.subscriptions.push(vscode.languages.registerFoldingRangeProvider(ParserContext.ebnfSelector, new EBNFFoldingRangeProvider()));
+    context.subscriptions.push(vscode.languages.registerCodeLensProvider(ParserContext.ebnfSelector, new EBNFCodeLensProvider()));
+    context.subscriptions.push(vscode.languages.registerDocumentSemanticTokensProvider(ParserContext.ebnfSelector, new EBNFSemanticTokensProvider(), EBNF_SEMANTIC_TOKENS_LEGEND));
     context.subscriptions.push(ParserContext.ebnfStatusBarItem);
 
     if (vscode.window.activeTextEditor) {
@@ -80,8 +86,8 @@ function registerFormatting(): vscode.Disposable {
     const formattingProvider = new EBNFFormattingProvider();
 
     return vscode.Disposable.from(
-        vscode.languages.registerDocumentFormattingEditProvider(ParserContext.ebnfSelector, formattingProvider)
-        // vscode.languages.registerDocumentRangeFormattingEditProvider(ParserContext.ebnfSelector, formattingProvider)
-        // vscode.languages.registerOnTypeFormattingEditProvider(ParserContext.ebnfSelector, formattingProvider, ";", ".", "\n") //, "}", ":)", "]", "/)", "*)", ","
+        vscode.languages.registerDocumentFormattingEditProvider(ParserContext.ebnfSelector, formattingProvider),
+        vscode.languages.registerDocumentRangeFormattingEditProvider(ParserContext.ebnfSelector, formattingProvider),
+        vscode.languages.registerOnTypeFormattingEditProvider(ParserContext.ebnfSelector, formattingProvider, ";", ".")
     );
 }

--- a/src/listeners/ASTListener.ts
+++ b/src/listeners/ASTListener.ts
@@ -17,6 +17,8 @@ export interface RuleInfo {
     stopToken: Token;
     /** Leading comment texts attached to the rule name, in source order. */
     comments: string[];
+    /** The parse-tree context for the whole syntax-rule (used by range/on-type formatting). */
+    ctx: SyntaxRuleContext;
 }
 
 export class ASTListener implements EBNFParserListener {
@@ -48,7 +50,8 @@ export class ASTListener implements EBNFParserListener {
                     nameToken: ruleName.symbol,
                     startToken,
                     stopToken,
-                    comments
+                    comments,
+                    ctx
                 });
             }
         }

--- a/src/providers/EBNFCodeActionsProvider.ts
+++ b/src/providers/EBNFCodeActionsProvider.ts
@@ -1,11 +1,15 @@
 import * as vscode from "vscode";
 import { HYPHEN_DIAGNOSTIC_CODE, convertIdentifier } from "../migration/IdentifierMigration";
 import { CONVERT_IDENTIFIERS_COMMAND } from "../commands/ConvertIdentifiers";
+import { DiagnosticCode } from "../analysis/GrammarAnalyzer";
+import { ParserContext } from "../ParserContext";
+import { ruleRange } from "./ProviderUtils";
 
 /**
- * Quick Fixes for the hyphen-in-identifier deprecation (#36):
- *  - per-identifier: replace "-" with "_" in the offending identifier (direct, undoable edit);
- *  - whole-file: run `EBNF: Convert identifiers…` (target choice + Refactor Preview).
+ * Quick Fixes for EBNF diagnostics:
+ *  - hyphen-in-identifier deprecation (#36): per-identifier "-"→"_" and a whole-file convert;
+ *  - undefined rule (G1): create a stub for the missing rule;
+ *  - unused rule (G3): delete the offending rule.
  * Edits are in-memory and undoable — nothing is written to disk until the user saves.
  */
 export class EBNFCodeActionsProvider implements vscode.CodeActionProvider {
@@ -20,6 +24,13 @@ export class EBNFCodeActionsProvider implements vscode.CodeActionProvider {
             return []; // don't offer edits on diff/git/untitled/virtual documents
         }
 
+        return [
+            ...this.hyphenActions(document, context),
+            ...this.semanticActions(document, context)
+        ];
+    }
+
+    private hyphenActions(document: vscode.TextDocument, context: vscode.CodeActionContext): vscode.CodeAction[] {
         const hyphenDiagnostics = context.diagnostics.filter(EBNFCodeActionsProvider.isHyphenDiagnostic);
         if (hyphenDiagnostics.length === 0) {
             return [];
@@ -47,6 +58,70 @@ export class EBNFCodeActionsProvider implements vscode.CodeActionProvider {
         actions.push(convertAll);
 
         return actions;
+    }
+
+    private semanticActions(document: vscode.TextDocument, context: vscode.CodeActionContext): vscode.CodeAction[] {
+        const actions: vscode.CodeAction[] = [];
+
+        for (const diagnostic of context.diagnostics) {
+            if (diagnostic.code === DiagnosticCode.UndefinedRule) {
+                const action = this.createRuleAction(document, diagnostic);
+                if (action) {
+                    actions.push(action);
+                }
+            }
+            else if (diagnostic.code === DiagnosticCode.UnusedRule) {
+                const action = this.removeRuleAction(document, diagnostic);
+                if (action) {
+                    actions.push(action);
+                }
+            }
+        }
+
+        return actions;
+    }
+
+    /** G1: append a stub definition for a rule that is used but never defined. */
+    private createRuleAction(document: vscode.TextDocument, diagnostic: vscode.Diagnostic): vscode.CodeAction | undefined {
+        const name = document.getText(diagnostic.range);
+        if (!name) {
+            return undefined;
+        }
+
+        const fix = new vscode.CodeAction(`Create rule "${name}"`, vscode.CodeActionKind.QuickFix);
+        fix.diagnostics = [diagnostic];
+        fix.edit = new vscode.WorkspaceEdit();
+
+        const end = document.lineAt(document.lineCount - 1).range.end;
+        const prefix = end.character === 0 ? "\n" : "\n\n";
+        fix.edit.insert(document.uri, end, `${prefix}${name} = ;`);
+
+        return fix;
+    }
+
+    /** G3: delete the whole syntax-rule flagged as unused. */
+    private removeRuleAction(document: vscode.TextDocument, diagnostic: vscode.Diagnostic): vscode.CodeAction | undefined {
+        const listener = ParserContext.getListener(document);
+        const rule = listener?.rules.find(r =>
+            r.nameToken.line - 1 === diagnostic.range.start.line &&
+            r.nameToken.column === diagnostic.range.start.character);
+
+        if (!rule) {
+            return undefined;
+        }
+
+        const extent = ruleRange(rule);
+        // Delete the rule's full lines including the trailing newline, if any.
+        const deletion = new vscode.Range(
+            new vscode.Position(extent.start.line, 0),
+            new vscode.Position(Math.min(extent.end.line + 1, document.lineCount), 0));
+
+        const fix = new vscode.CodeAction(`Remove unused rule "${rule.name}"`, vscode.CodeActionKind.QuickFix);
+        fix.diagnostics = [diagnostic];
+        fix.edit = new vscode.WorkspaceEdit();
+        fix.edit.delete(document.uri, deletion);
+
+        return fix;
     }
 
     private static isHyphenDiagnostic(diagnostic: vscode.Diagnostic): boolean {

--- a/src/providers/EBNFCodeLensProvider.ts
+++ b/src/providers/EBNFCodeLensProvider.ts
@@ -1,0 +1,32 @@
+import * as vscode from "vscode";
+import { ParserContext } from "../ParserContext";
+import { tokenRange } from "./ProviderUtils";
+
+export class EBNFCodeLensProvider implements vscode.CodeLensProvider {
+    public provideCodeLenses(
+        document: vscode.TextDocument,
+        _: vscode.CancellationToken): vscode.ProviderResult<vscode.CodeLens[]>
+    {
+        const listener = ParserContext.getListener(document);
+        if (!listener) {
+            return;
+        }
+
+        return listener.rules
+            .filter(rule => rule.name.length > 0)
+            .map(rule => {
+                const locations = listener.usages
+                    .filter(usage => usage.text === rule.name)
+                    .map(usage => new vscode.Location(document.uri, tokenRange(usage)));
+
+                const nameRange = tokenRange(rule.nameToken);
+                const command: vscode.Command = {
+                    title: `${locations.length} reference${locations.length === 1 ? "" : "s"}`,
+                    command: "editor.action.showReferences",
+                    arguments: [document.uri, nameRange.start, locations]
+                };
+
+                return new vscode.CodeLens(nameRange, command);
+            });
+    }
+}

--- a/src/providers/EBNFFoldingRangeProvider.ts
+++ b/src/providers/EBNFFoldingRangeProvider.ts
@@ -1,0 +1,60 @@
+import * as vscode from "vscode";
+import { ParserContext } from "../ParserContext";
+
+// Region markers, mirroring syntaxes/ebnf.configuration.json `folding.markers`. Registering
+// a FoldingRangeProvider replaces the language-configuration marker folding, so we re-emit it
+// here to keep (* region *) / (* endregion *) blocks foldable.
+const REGION_START = /^\(\*\s*region(\s*\w*)*\*\)/;
+const REGION_END = /^\(\*\s*endregion\s*\*\)/;
+
+export class EBNFFoldingRangeProvider implements vscode.FoldingRangeProvider {
+    public provideFoldingRanges(
+        document: vscode.TextDocument,
+        _context: vscode.FoldingContext,
+        _: vscode.CancellationToken): vscode.ProviderResult<vscode.FoldingRange[]>
+    {
+        const listener = ParserContext.getListener(document);
+        if (!listener) {
+            return;
+        }
+
+        // Structural folding: one region per multi-line syntax-rule. We fold from the rule's
+        // name line (not ctx.start) because a rule's *leading* comments belong to its context;
+        // folding from ctx.start would swallow a preceding (* region *) / (* endregion *) marker
+        // into the rule and break marker-based folding. Marker folding comes from the language
+        // configuration and now stays independent.
+        const ranges: vscode.FoldingRange[] = [];
+        for (const rule of listener.rules) {
+            const startLine = rule.nameToken.line - 1;
+            const endLine = rule.stopToken.line - 1;
+            if (endLine > startLine) {
+                ranges.push(new vscode.FoldingRange(startLine, endLine));
+            }
+        }
+
+        ranges.push(...this.regionRanges(document));
+
+        return ranges;
+    }
+
+    /** Marker-based folding: pair (* region *) with (* endregion *), supporting nesting. */
+    private regionRanges(document: vscode.TextDocument): vscode.FoldingRange[] {
+        const ranges: vscode.FoldingRange[] = [];
+        const starts: number[] = [];
+
+        for (let line = 0; line < document.lineCount; line++) {
+            const text = document.lineAt(line).text;
+            if (REGION_START.test(text)) {
+                starts.push(line);
+            }
+            else if (REGION_END.test(text)) {
+                const start = starts.pop();
+                if (start !== undefined && line > start) {
+                    ranges.push(new vscode.FoldingRange(start, line, vscode.FoldingRangeKind.Region));
+                }
+            }
+        }
+
+        return ranges;
+    }
+}

--- a/src/providers/EBNFFormattingProvider.ts
+++ b/src/providers/EBNFFormattingProvider.ts
@@ -1,122 +1,109 @@
 import * as vscode from "vscode";
 import { EBNFLexer } from "../parser/EBNFLexer";
-import { CharStream, CommonTokenStream } from "antlr4ng";
-import { EBNFParser } from "../parser/EBNFParser";
+import { CharStream, CommonTokenStream, ParseTreeListener } from "antlr4ng";
+import { EBNFParser, SyntaxContext } from "../parser/EBNFParser";
 import { FormattingVisitor } from "../visitors/FormattingVisitor";
 import { EBNFFormattingOptions } from "./EBNFFormattingOptions";
 import { ParserContext } from "../ParserContext";
+import { ASTListener, RuleInfo } from "../listeners/ASTListener";
 
-export class EBNFFormattingProvider implements vscode.DocumentFormattingEditProvider //, vscode.OnTypeFormattingEditProvider, vscode.DocumentRangeFormattingEditProvider
-{
-    provideDocumentFormattingEdits(document: vscode.TextDocument, options: vscode.FormattingOptions, token: vscode.CancellationToken): vscode.ProviderResult<vscode.TextEdit[]> {
-        const hasErrors = vscode.languages.getDiagnostics(document.uri)
-            .some(d => d.severity === vscode.DiagnosticSeverity.Error);
-        if (hasErrors) {
+export class EBNFFormattingProvider implements
+    vscode.DocumentFormattingEditProvider,
+    vscode.DocumentRangeFormattingEditProvider,
+    vscode.OnTypeFormattingEditProvider {
+
+    provideDocumentFormattingEdits(document: vscode.TextDocument, options: vscode.FormattingOptions, _token: vscode.CancellationToken): vscode.ProviderResult<vscode.TextEdit[]> {
+        if (this.hasErrors(document)) {
             vscode.window.showInformationMessage("Fix all syntax errors before formatting the document.");
             return [];
         }
 
         const content: string = document.getText();
-        const formattedText = this.format(content, options);
+        const { syntax } = this.parse(content);
+        const formattedText = new FormattingVisitor(this.formattingOptions(options)).visit(syntax) ?? "";
 
-        var fullRange = new vscode.Range(
+        const fullRange = new vscode.Range(
             document.positionAt(0),
             document.positionAt(content.length));
 
         return [vscode.TextEdit.replace(fullRange, formattedText)];
-    };
+    }
 
-    // provideDocumentRangeFormattingEdits(document: vscode.TextDocument, range: vscode.Range, options: vscode.FormattingOptions, token: vscode.CancellationToken): vscode.ProviderResult<vscode.TextEdit[]> {
-    //     const hasDiagnostics = vscode.languages.getDiagnostics(document.uri).length > 0;
-    //     if (hasDiagnostics) {
-    //         vscode.window.showInformationMessage("Fix all syntax errors before formatting the document.");
-    //         return [];
-    //     }
+    // G18 — format only the syntax-rules overlapping the selection.
+    provideDocumentRangeFormattingEdits(document: vscode.TextDocument, range: vscode.Range, options: vscode.FormattingOptions, _token: vscode.CancellationToken): vscode.ProviderResult<vscode.TextEdit[]> {
+        if (this.hasErrors(document)) {
+            return [];
+        }
 
-    //     // Parse the whole document
-    //     const fullContent: string = document.getText();
-    //     const inputStream = CharStream.fromString(fullContent);
-    //     const lexer = new EBNFLexer(inputStream);
-    //     const tokenStream = new CommonTokenStream(lexer);
-    //     const parser = new EBNFParser(tokenStream);
-    //     const syntax = parser.syntax();
+        const selectionStart = document.offsetAt(range.start);
+        const selectionEnd = document.offsetAt(range.end);
 
-    //     // Find all syntax rules that overlap with the selection
-    //     // Assuming EBNFParser.SyntaxRuleContext is the context for a syntax rule
-    //     // and syntax.children contains all rules
-    //     const rulesToFormat: SyntaxRuleContext[] = [];
-    //     const selectionStart = document.offsetAt(range.start);
-    //     const selectionEnd = document.offsetAt(range.end);
+        return this.formatRules(document, options, rule => {
+            const ruleStart = rule.startToken.start;
+            const ruleEnd = rule.stopToken.stop + 1;
+            return ruleEnd > selectionStart && ruleStart < selectionEnd;
+        });
+    }
 
-    //     function collectRules(node: ParserRuleContext | null) {
-    //         if (!node) return;
-    //         if (node instanceof SyntaxRuleContext) {
-    //             const ruleStart = node.start.start;
-    //             const ruleEnd = node.stop.stop + 1; // stopIndex is inclusive
-    //             if (ruleEnd > selectionStart && ruleStart < selectionEnd) {
-    //                 rulesToFormat.push(node);
-    //             }
-    //         }
-    //         if (node.children) {
-    //             for (const child of node.children) {
-    //                 collectRules(child as ParserRuleContext);
-    //             }
-    //         }
-    //     }
-    //     collectRules(syntax);
+    // G19 — reformat the rule just completed when a terminator (or newline) is typed.
+    provideOnTypeFormattingEdits(document: vscode.TextDocument, position: vscode.Position, _ch: string, options: vscode.FormattingOptions, _token: vscode.CancellationToken): vscode.ProviderResult<vscode.TextEdit[]> {
+        if (this.hasErrors(document)) {
+            return [];
+        }
 
-    //     if (rulesToFormat.length === 0) {
-    //         // No rules found in selection, do nothing
-    //         return [];
-    //     }
+        const offset = document.offsetAt(position);
 
-    //     // Format each rule and build edits
-    //     const edits: vscode.TextEdit[] = [];
-    //     const formattingOptions = this.formattingOptions(options);
-    //     const visitor = new FormattingVisitor(formattingOptions);
-    //     for (const rule of rulesToFormat) {
-    //         const ruleStart = rule.start.start;
-    //         const ruleEnd = rule.stop.stop + 1;
-    //         //const ruleText = fullContent.substring(ruleStart, ruleEnd);
-    //         const formatted = visitor.visit(rule);
-    //         const startPos = document.positionAt(ruleStart);
-    //         const endPos = document.positionAt(ruleEnd);
-    //         edits.push(vscode.TextEdit.replace(new vscode.Range(startPos, endPos), formatted));
-    //     }
-        
-    //     return edits;
-    // };
+        return this.formatRules(document, options, rule => {
+            const ruleStart = rule.startToken.start;
+            const ruleEnd = rule.stopToken.stop + 1;
+            return ruleStart <= offset && offset <= ruleEnd;
+        });
+    }
 
-    // provideOnTypeFormattingEdits(document: vscode.TextDocument, position: vscode.Position, ch: string, options: vscode.FormattingOptions, token: vscode.CancellationToken): vscode.ProviderResult<vscode.TextEdit[]> {
-    //     const hasDiagnostics = vscode.languages.getDiagnostics(document.uri).length > 0;
-    //     if (hasDiagnostics) {
-    //         vscode.window.showInformationMessage("Fix all syntax errors before formatting the document.");
-    //         return [];
-    //     }
+    /** Formats each syntax-rule matching the predicate and returns replacement edits. */
+    private formatRules(document: vscode.TextDocument, options: vscode.FormattingOptions, predicate: (rule: RuleInfo) => boolean): vscode.TextEdit[] {
+        const { listener } = this.parse(document.getText());
+        const visitor = new FormattingVisitor(this.formattingOptions(options));
 
-    //     let line = document.lineAt(position.line);
-    //     let lineRange = line.range;
+        const edits: vscode.TextEdit[] = [];
+        for (const rule of listener.rules) {
+            if (!predicate(rule)) {
+                continue;
+            }
 
-    //     const content: string = document.getText(lineRange);
-    //     const formattedText = this.format(content, options);
+            const formatted = visitor.visit(rule.ctx) ?? "";
+            const ruleRange = new vscode.Range(
+                document.positionAt(rule.startToken.start),
+                document.positionAt(rule.stopToken.stop + 1));
+            edits.push(vscode.TextEdit.replace(ruleRange, formatted));
+        }
 
-    //     return [vscode.TextEdit.replace(lineRange, formattedText)];
-    // }
+        return edits;
+    }
 
-    private format(content: string, options: vscode.FormattingOptions): string {
+    private parse(content: string): { syntax: SyntaxContext; listener: ASTListener } {
         const inputStream = CharStream.fromString(content);
         const lexer = new EBNFLexer(inputStream);
         const tokenStream = new CommonTokenStream(lexer);
         const parser = new EBNFParser(tokenStream);
+
+        const listener = new ASTListener();
+        parser.removeParseListeners();
+        parser.addParseListener(listener as unknown as ParseTreeListener);
+
         const syntax = parser.syntax();
-        var visitor = new FormattingVisitor(this.formattingOptions(options));
-        return visitor.visit(syntax) ?? "";
+        return { syntax, listener };
+    }
+
+    private hasErrors(document: vscode.TextDocument): boolean {
+        return vscode.languages.getDiagnostics(document.uri)
+            .some(d => d.severity === vscode.DiagnosticSeverity.Error);
     }
 
     private formattingOptions(vsOptions: vscode.FormattingOptions): EBNFFormattingOptions {
         const settings = vscode.workspace.getConfiguration(ParserContext.ebnfName);
 
-        var options = new EBNFFormattingOptions();
+        const options = new EBNFFormattingOptions();
         options.enable = settings.get<boolean>("format.enable", true);
         options.tabSize = vsOptions.tabSize;
         options.insertSpaces = vsOptions.insertSpaces;

--- a/src/providers/EBNFSemanticTokensProvider.ts
+++ b/src/providers/EBNFSemanticTokensProvider.ts
@@ -1,0 +1,43 @@
+import * as vscode from "vscode";
+import { ParserContext } from "../ParserContext";
+import { tokenRange } from "./ProviderUtils";
+
+/**
+ * Semantic-token legend. We only colour meta-identifiers that are *used but never defined*
+ * (as `variable`), so they stand out from resolved references even before the G1 diagnostic
+ * is read. Defined identifiers are intentionally left to the TextMate grammar, which already
+ * distinguishes a rule declaration (LHS) from a reference (RHS) — emitting semantic tokens for
+ * them would override and flatten that distinction.
+ */
+export const EBNF_SEMANTIC_TOKENS_LEGEND = new vscode.SemanticTokensLegend(
+    ["variable"],
+    []);
+
+export class EBNFSemanticTokensProvider implements vscode.DocumentSemanticTokensProvider {
+    public provideDocumentSemanticTokens(
+        document: vscode.TextDocument,
+        _: vscode.CancellationToken): vscode.ProviderResult<vscode.SemanticTokens>
+    {
+        const listener = ParserContext.getListener(document);
+        if (!listener) {
+            return;
+        }
+
+        const definedNames = new Set(
+            listener.definitions
+                .map(d => d.text)
+                .filter((name): name is string => name !== undefined && name.length > 0));
+
+        // Only undefined usages, in ascending (line, column) order as the builder requires.
+        const undefinedUsages = listener.usages
+            .filter(usage => usage.text !== undefined && !definedNames.has(usage.text))
+            .sort((a, b) => a.line - b.line || a.column - b.column);
+
+        const builder = new vscode.SemanticTokensBuilder(EBNF_SEMANTIC_TOKENS_LEGEND);
+        for (const usage of undefinedUsages) {
+            builder.push(tokenRange(usage), "variable", []);
+        }
+
+        return builder.build();
+    }
+}

--- a/src/visitors/FormattingVisitor.ts
+++ b/src/visitors/FormattingVisitor.ts
@@ -110,45 +110,56 @@ export class FormattingVisitor extends AbstractParseTreeVisitor<string> implemen
     }
 
     public visitDefinitionsList(ctx: DefinitionsListContext): string {
+        // Grammar: singleDefinition (DEFINITION_SEPARATOR_SYMBOL comment* singleDefinition)*.
+        // We walk the children in order so each comment stays attached to the separator it
+        // follows. Emitting ctx.comment() after every separator duplicated/misplaced them (B3).
         var result: string = "";
-        var first: boolean = true;
+        var firstDefinition: boolean = true;
 
-        for (var def of ctx.singleDefinition()) {
-            if (!first) {
+        for (const child of ctx.children ?? []) {
+            if (child instanceof SingleDefinitionContext) {
+                if (!firstDefinition) {
+                    result += " ";
+                }
+                result += this.visit(child);
+                firstDefinition = false;
+            }
+            else if (child instanceof CommentContext) {
+                result += " " + this.visit(child);
+            }
+            else {
+                // DEFINITION_SEPARATOR_SYMBOL terminal.
                 result += this.options.definitionSeparatorSymbolOnNewLine ? "\n" : " ";
                 result += (this.options.definitionSeparatorSymbolOnNewLine && this.options.indentDefiningSymbol) ? this.indent() : "";
-                result += this.options.defaultDefinitionSeparatorSymbol; // ctx.DEFINITION_SEPARATOR_SYMBOL()[i].symbol.text;
-                ctx.comment().forEach((comment: CommentContext) => {
-                    result += " " + this.visit(comment);
-                });
-                result += " ";
+                result += this.options.defaultDefinitionSeparatorSymbol; // original: child.getText()
             }
-
-            result += this.visit(def);
-            first = false;
         }
 
         return result;
     }
 
     public visitSingleDefinition(ctx: SingleDefinitionContext): string {
+        // Grammar: syntacticTerm (CONCATENATE_SYMBOL comment* syntacticTerm)*. Walk children in
+        // order so comments stay with their concatenate-symbol rather than being repeated (B3).
         var result: string = "";
-        var first: boolean = true;
-        var i: number = 0;
+        var firstTerm: boolean = true;
 
-        for (var term of ctx.syntacticTerm()) {
-            if (!first) {
-                result += this.options.insertSpaceBeforeConcatenateSymbol ? " " : "";
-                result += ctx.CONCATENATE_SYMBOL()[i].symbol.text;
-                ctx.comment().forEach((comment: CommentContext) => {
-                    result += " " + this.visit(comment);
-                });
-                result += " ";
-                i += 1;
+        for (const child of ctx.children ?? []) {
+            if (child instanceof SyntacticTermContext) {
+                if (!firstTerm) {
+                    result += " ";
+                }
+                result += this.visit(child);
+                firstTerm = false;
             }
-
-            result += this.visit(term);
-            first = false;
+            else if (child instanceof CommentContext) {
+                result += " " + this.visit(child);
+            }
+            else {
+                // CONCATENATE_SYMBOL terminal.
+                result += this.options.insertSpaceBeforeConcatenateSymbol ? " " : "";
+                result += child.getText();
+            }
         }
 
         return result;

--- a/tests/FormattingVisitorTests.ts
+++ b/tests/FormattingVisitorTests.ts
@@ -1,0 +1,60 @@
+import { SyntaxContext } from "../src/parser/EBNFParser";
+import { parseRule, collectErrorNodes } from "./utils";
+import { FormattingVisitor } from "../src/visitors/FormattingVisitor";
+import { EBNFFormattingOptions } from "../src/providers/EBNFFormattingOptions";
+
+function format(input: string, tweak?: (o: EBNFFormattingOptions) => void): string {
+    const syntax: SyntaxContext = parseRule('syntax', input);
+    expect(collectErrorNodes(syntax)).toHaveLength(0);
+
+    const options = new EBNFFormattingOptions();
+    // Keep separators inline so the output is easy to assert on a single line.
+    options.definitionSeparatorSymbolOnNewLine = false;
+    tweak?.(options);
+
+    return new FormattingVisitor(options).visit(syntax) ?? "";
+}
+
+function count(haystack: string, needle: string): number {
+    return haystack.split(needle).length - 1;
+}
+
+// B3 — comments must not be duplicated/misplaced across separators in a definitions-list.
+test('B3 - each definitions-list comment is emitted exactly once, next to its own separator', () => {
+    const result = format(`rule = a | (* first *) b | (* second *) c;`);
+
+    expect(count(result, "(* first *)")).toBe(1);
+    expect(count(result, "(* second *)")).toBe(1);
+    // The comment attaches to the separator that precedes its alternative.
+    expect(result).toContain("| (* first *) b");
+    expect(result).toContain("| (* second *) c");
+});
+
+// B3 — same defect existed for concatenation comments in a single-definition.
+test('B3 - each single-definition comment is emitted exactly once, next to its own concatenate symbol', () => {
+    const result = format(`rule = a , (* first *) b , (* second *) c;`);
+
+    expect(count(result, "(* first *)")).toBe(1);
+    expect(count(result, "(* second *)")).toBe(1);
+    expect(result).toContain(", (* first *) b");
+    expect(result).toContain(", (* second *) c");
+});
+
+test('B3 - formatter output re-parses without errors', () => {
+    const result = format(`rule = a | (* first *) b | (* second *) c;`);
+    const reparsed: SyntaxContext = parseRule('syntax', result);
+    expect(collectErrorNodes(reparsed)).toHaveLength(0);
+});
+
+// G18/G19 — range and on-type formatting re-serialize a single syntaxRule context.
+test('G18/G19 - a single syntaxRule formats independently and re-parses', () => {
+    const ruleCtx = parseRule('syntaxRule', `rule=a,b|c;`);
+    const options = new EBNFFormattingOptions();
+    options.definitionSeparatorSymbolOnNewLine = false;
+    options.definingSymbolOnNewLine = false;
+
+    const formatted = new FormattingVisitor(options).visit(ruleCtx) ?? "";
+
+    expect(formatted).toContain("rule = a, b | c");
+    expect(collectErrorNodes(parseRule('syntax', formatted))).toHaveLength(0);
+});


### PR DESCRIPTION
## Milestone M3 — Polish the editor experience

Adds the "editor comfort" layer on top of the M2 semantic model and fixes the last known formatter bug.

### Formatter
- **B3** — comments in a definitions-list / single-definition are no longer duplicated or attached to the wrong separator. The visitor now walks children in source order so each comment stays with the separator/concatenate-symbol it follows.

### New editor providers
| Item | Feature |
|------|---------|
| **G13** | **Folding** — one region per multi-line rule (folds from the rule's *name* line, so leading doc-comments aren't swallowed). Also re-emits `(* region *)` / `(* endregion *)` marker folds, since registering a folding provider otherwise suppresses the language-configuration markers. |
| **G10** | **Semantic tokens** — flags a meta-identifier that is *used but never defined* (`variable`). Defined identifiers are deliberately left to the TextMate grammar so the existing LHS-declaration vs RHS-reference colouring is preserved. |
| **G12** | **CodeLens** — "N references" above each rule, click to peek. |
| **G17** | **Quick fixes** (extends the hyphen-migration code-action provider): "Create rule" for an undefined rule (G1), "Remove unused rule" for an unused rule (G3). |
| **G18** | **Range formatting** — formats only the rules overlapping the selection. |
| **G19** | **On-type formatting** — reformats the completed rule on `;` / `.`. |

### Supporting changes
- `RuleInfo` now carries the `SyntaxRuleContext` so range/on-type formatting can re-serialize a single rule; the formatting provider parses independently (fresh listener) to avoid global-state staleness.
- Register the new providers and enable range/on-type formatting; update the `package.json` capabilities block.

### Notes / decisions
- Folding starts at the rule name line (leading comments stay independent); region markers are re-derived from the same regexes as the language config, with nesting support.
- Semantic tokens only recolour undefined references — the value TextMate can't provide — rather than overriding all identifiers.
- On-type formatting requires `editor.formatOnType` (off by default in VS Code); both formatters no-op while the document has error diagnostics.

### Verification
- `tsc --noEmit` (strict): 0 errors
- `npm test`: 71/71 pass (4 new formatter tests incl. B3 regressions)
- `npm run package` (production webpack): builds clean
- Manually validated end-to-end in the Extension Development Host: B3, folding (+ region markers), semantic tokens (multiple themes), CodeLens, "Create rule" / "Remove unused rule", range & on-type formatting.